### PR TITLE
Changed text inside tiers to be always black

### DIFF
--- a/app/src/main/java/com/dessalines/rankmyfavs/ui/components/favlist/TierListScreen.kt
+++ b/app/src/main/java/com/dessalines/rankmyfavs/ui/components/favlist/TierListScreen.kt
@@ -374,7 +374,7 @@ fun TierSection(
                     fontStyle = if (editTierList) FontStyle.Italic else FontStyle.Normal,
                     fontSize = textSize,
                     style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = Color.Black,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -399,7 +399,7 @@ fun TierSection(
                     text = item.name,
                     style = MaterialTheme.typography.bodySmall,
                     modifier = Modifier.padding(vertical = SMALL_PADDING),
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = Color.Black,
                 )
             }
         }


### PR DESCRIPTION
Closes #172 

Changed text of tier name and tier items to always be black so that it contrasts with whatever color the tier is selected to be